### PR TITLE
Fix POSIX-compatibility in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,19 @@ include config.mk
 all: libschrift.a sftdemo stress
 
 libschrift.a: schrift.o
-	$(AR) rc $@ $^$>
+	$(AR) rc $@ schrift.o
 	$(RANLIB) $@
 schrift.o: schrift.h
 
 sftdemo: sftdemo.o libschrift.a
-	$(LD) $(LDFLAGS) $< -o $@ -L$(X11LIB) -L. -lX11 -lXrender -lschrift -lm
+	$(LD) $(LDFLAGS) $@.o -o $@ -L$(X11LIB) -L. -lX11 -lXrender -lschrift -lm
 sftdemo.o: sftdemo.c schrift.h arg.h
-	$(CC) -c $(CFLAGS) $< -o $@ $(CPPFLAGS) -I$(X11INC)
+	$(CC) -c $(CFLAGS) $(@:.o=.c) -o $@ $(CPPFLAGS) -I$(X11INC)
 
 stress: stress.o libschrift.a
-	$(LD) $(LDFLAGS) $< -o $@ -L. -lschrift -lm
+	$(LD) $(LDFLAGS) $@.o -o $@ -L. -lschrift -lm
 stress.o: stress.c schrift.h arg.h
-	$(CC) -c $(CFLAGS) $< -o $@ $(CPPFLAGS)
+	$(CC) -c $(CFLAGS) $(@:.o=.c) -o $@ $(CPPFLAGS)
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
`$^` is does not exist in POSIX Make.
`$>` does not exist in GNU or POSIX Make, so I assume this is an error.
POSIX Make defines `$<` as unspecified out of inference rules (e.g. `.c.o`) and `.DEFAULT`.

The POSIX man page for make(1), also specifies that, `.POSIX:` must appear on the first non-comment line for the behaviour of make(1) to be specified, but I assume they just forgot to also say non-blank.