### PR TITLE
Define SFT_Glyph as uint_fast32_t to fix build on darwin

### DIFF
--- a/schrift.h
+++ b/schrift.h
@@ -17,6 +17,8 @@
 #ifndef SCHRIFT_H
 #define SCHRIFT_H 1
 
+#include <stdint.h> /* uint_fast32_t */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +27,7 @@ extern "C" {
 
 typedef struct SFT          SFT;
 typedef struct SFT_Font     SFT_Font;
-typedef unsigned long       SFT_Glyph;
+typedef uint_fast32_t       SFT_Glyph;
 typedef struct SFT_LMetrics SFT_LMetrics;
 typedef struct SFT_GMetrics SFT_GMetrics;
 typedef struct SFT_Kerning  SFT_Kerning;


### PR DESCRIPTION
On darwin uint_fast32_t is a unsigned int, not a unsigned long int,
leading to conflicting definitions between schrift.h and functions in
schrift.c using uint32_fast_t instead of SFT_Glyph.

https://opensource.apple.com/source/Libc/Libc-1439.40.11/include/_types/_uint32_t.h.auto.html