### PR TITLE
Fix compilation for 32bit

### DIFF
--- a/schrift.c
+++ b/schrift.c
@@ -141,14 +141,14 @@ static inline int_least16_t  geti16(SFT_Font *font, uint_fast32_t offset);
 static inline uint_least32_t getu32(SFT_Font *font, uint_fast32_t offset);
 static int gettable(SFT_Font *font, char tag[4], uint_fast32_t *offset);
 /* codepoint to glyph id translation */
-static int  cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, uint_fast32_t *glyph);
-static int  cmap_fmt6(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, uint_fast32_t *glyph);
-static int  glyph_id(SFT_Font *font, uint_fast32_t charCode, uint_fast32_t *glyph);
+static int cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph);
+static int cmap_fmt6(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph);
+static int glyph_id(SFT_Font *font, uint_fast32_t charCode, SFT_Glyph *glyph);
 /* glyph metrics lookup */
-static int  hor_metrics(SFT_Font *font, uint_fast32_t glyph, int *advanceWidth, int *leftSideBearing);
+static int hor_metrics(SFT_Font *font, SFT_Glyph glyph, int *advanceWidth, int *leftSideBearing);
 static int  glyph_bbox(const SFT *sft, unsigned long outline, int box[4]);
 /* decoding outlines */
-static int  outline_offset(SFT_Font *font, uint_fast32_t glyph, uint_fast32_t *offset);
+static int outline_offset(SFT_Font *font, SFT_Glyph glyph, uint_fast32_t *offset);
 static int  simple_flags(SFT_Font *font, uint_fast32_t *offset, uint_fast16_t numPts, uint8_t *flags);
 static int  simple_points(SFT_Font *font, uint_fast32_t offset, uint_fast16_t numPts, uint8_t *flags, Point *points);
 static int  decode_contour(uint8_t *flags, uint_fast16_t basePoint, uint_fast16_t count, Outline *outl);
@@ -253,7 +253,7 @@ sft_gmetrics(const SFT *sft, SFT_Glyph glyph, SFT_GMetrics *metrics)
 {
 	int adv, lsb;
 	double xScale = sft->xScale / sft->font->unitsPerEm;
-	unsigned long outline;
+	uint_fast32_t outline;
 	int bbox[4];
 
 	memset(metrics, 0, sizeof *metrics);
@@ -345,7 +345,7 @@ sft_kerning(const SFT *sft, SFT_Glyph leftGlyph, SFT_Glyph rightGlyph,
 int
 sft_render(const SFT *sft, SFT_Glyph glyph, SFT_Image image)
 {
-	unsigned long outline;
+	uint_fast32_t outline;
 	double transform[6];
 	int bbox[4];
 	Outline outl;


### PR DESCRIPTION
cmap_fmt4, cmap_fmt6 and glyph_id functions declaration and definition didn't match, causing errors when compiling for 32bit (-m32 compiler and linker flag). Some variables were created as unsigned long, pointer to them was passed to functions taking uint_fast_32_t* which is unsigned long int* (not the same as unsigned long*). I think the whole uint_fast_32_t can be replaced with just unsigned int, but I didn't do it in this PR.