### PR TITLE
Fixed OSx build

### DIFF
--- a/schrift.c
+++ b/schrift.c
@@ -141,14 +141,14 @@ static inline int_least16_t  geti16(SFT_Font *font, uint_fast32_t offset);
 static inline uint_least32_t getu32(SFT_Font *font, uint_fast32_t offset);
 static int gettable(SFT_Font *font, char tag[4], uint_fast32_t *offset);
 /* codepoint to glyph id translation */
-static int  cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, uint_fast32_t *glyph);
-static int  cmap_fmt6(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, uint_fast32_t *glyph);
-static int  glyph_id(SFT_Font *font, uint_fast32_t charCode, uint_fast32_t *glyph);
+static int  cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph);
+static int  cmap_fmt6(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph);
+static int  glyph_id(SFT_Font *font, uint_fast32_t charCode, SFT_Glyph *glyph);
 /* glyph metrics lookup */
-static int  hor_metrics(SFT_Font *font, uint_fast32_t glyph, int *advanceWidth, int *leftSideBearing);
+static int  hor_metrics(SFT_Font *font, SFT_Glyph glyph, int *advanceWidth, int *leftSideBearing);
 static int  glyph_bbox(const SFT *sft, unsigned long outline, int box[4]);
 /* decoding outlines */
-static int  outline_offset(SFT_Font *font, uint_fast32_t glyph, uint_fast32_t *offset);
+static int  outline_offset(SFT_Font *font, SFT_Glyph glyph, uint_fast32_t *offset);
 static int  simple_flags(SFT_Font *font, uint_fast32_t *offset, uint_fast16_t numPts, uint8_t *flags);
 static int  simple_points(SFT_Font *font, uint_fast32_t offset, uint_fast16_t numPts, uint8_t *flags, Point *points);
 static int  decode_contour(uint8_t *flags, uint_fast16_t basePoint, uint_fast16_t count, Outline *outl);
@@ -756,8 +756,7 @@ gettable(SFT_Font *font, char tag[4], uint_fast32_t *offset)
 	return 0;
 }
 
-static int
-cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph)
+static int cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph)
 {
 	uintptr_t segIdxX2;
 	uint_fast32_t endCodes, startCodes, idDeltas, idRangeOffsets, idOffset;


### PR DESCRIPTION
On MacOS `uint_fast32_t` is not equal to `unsigned long`.
Compilation failed because there is two different declaration with different types, eg:

```
static int cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, uint_fast32_t *glyph);
```
and
```
static int cmap_fmt4(SFT_Font *font, uint_fast32_t table, uint_fast32_t charCode, SFT_Glyph *glyph)
```