### PR TITLE
stress.c: fix type of gid, should be SFT_Glyph instead of unsigned long

### DIFF
--- a/stress.c
+++ b/stress.c
@@ -32,7 +32,8 @@ main(int argc, char *argv[])
 	SFT_Font *font;
 	const char *filename;
 	double size;
-	unsigned long cp, gid;
+	unsigned long cp;
+	SFT_Glyph gid;
 	SFT_GMetrics mtx;
 	SFT_Image    image;
 	int i;


### PR DESCRIPTION
found this issue while compiling "stress" on an M1 mac.  On that platform `sizeof(unsigned long) == 8` and `sizeof(SFT_Glyph) == 4`